### PR TITLE
Added native Windows port of pfsfuse

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,18 +106,56 @@ jobs:
           name: pfsshell-win32
           path: build/*.7z
 
-      # - name: Build pfsfuse
-      #   continue-on-error: true
-      #   run: |
-      #     sudo apt-get install mingw-w64-tools fuse libfuse-dev
-      #     rm -rf build/
-      #     meson setup build/ -Denable_pfsfuse=true --cross-file ./external/meson_toolchains/mingw32_meson.ini
-      #     meson compile -C build
+      - name: Build pfsfuse
+        continue-on-error: true
+        run: |
+          rm -rf build/
+          meson setup build/ -Denable_pfsfuse=true --cross-file ./external/meson_toolchains/mingw32_meson.ini
+          meson compile -C build
+          cp -f external/dokany/license.lgpl.txt build/
 
-      # - uses: actions/upload-artifact@master
-      #   with:
-      #     name: pfsfuse-win32
-      #     path: build/pfsfuse.exe
+      - uses: actions/upload-artifact@master
+        continue-on-error: true
+        with:
+          name: pfsfuse-win32
+          path: |
+            build/pfsfuse.exe
+            build/libdokanfuse*.dll
+            build/license.lgpl.txt
+
+  build-pfsfuse-win32:
+    runs-on: windows-latest
+    defaults:
+     run:
+      shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Install MSYS2 packages
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW32
+          install: |
+            base-devel git make texinfo patch binutils mpc-devel p7zip mingw-w64-i686-gcc
+            mingw-w64-i686-cmake mingw-w64-i686-extra-cmake-modules mingw-w64-i686-make mingw-w64-i686-meson
+          update: true
+          shell: msys2 {0}
+
+      - name: Build pfsfuse
+        run: |
+          meson setup build/ -Denable_pfsfuse=true
+          meson compile -C build
+          cp -f external/dokany/license.lgpl.txt build/
+
+      - uses: actions/upload-artifact@master
+        with:
+          name: pfsfuse-win32
+          path: |
+            build/pfsfuse.exe
+            build/libdokanfuse*.dll
+            build/license.lgpl.txt
 
   build-macos:
     runs-on: macos-10.15
@@ -166,7 +204,7 @@ jobs:
           path: build/pfsfuse
 
   create-release:
-    needs: [build-ubuntu, build-win32, build-macos]
+    needs: [build-ubuntu, build-win32, build-macos, build-pfsfuse-win32]
     runs-on: ubuntu-20.04
     if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master'
     steps:
@@ -179,6 +217,7 @@ jobs:
           7z a -tzip pfsshell-macos.zip pfsshell-macos/*
           7z a -tzip pfsfuse-ubuntu.zip pfsfuse-ubuntu/*
           7z a -tzip pfsfuse-macos.zip pfsfuse-macos/*
+          7z a -tzip pfsfuse-win32.zip pfsfuse-win32/*
 
       - name: Create prerelease
         if: github.ref == 'refs/heads/master'
@@ -190,6 +229,7 @@ jobs:
           title: "Latest development builds"
           files: |
             pfsshell-win32/*
+            pfsfuse-win32.zip
             pfsshell-ubuntu.zip
             pfsshell-macos.zip
             pfsfuse-ubuntu.zip
@@ -203,6 +243,7 @@ jobs:
           prerelease: "${{ contains(github.ref, '-rc') }}"
           files: |
             pfsshell-win32/*
+            pfsfuse-win32.zip
             pfsshell-ubuntu.zip
             pfsshell-macos.zip
             pfsfuse-ubuntu.zip

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "external/meson_toolchains"]
 	path = external/meson_toolchains
 	url = https://github.com/uyjulian/meson_toolchains.git
+[submodule "external/dokany"]
+	path = external/dokany
+	url = https://github.com/dokan-dev/dokany

--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ Once you are finished with the program, type in the following:
 ## pfsfuse
 
 `pfsfuse` provides an ability to mount partition into host filesystem (like network folder).
-Your system has to support fuse. For example, on the WSL2 `fuse` package should be installed, on the MacOs `macfuse` package can be used.
+`pfsfuse` supports physically connected drives, raw drive images as regular files, and an NBD network server from OPL.
+Your system has to support fuse. For example, in the Linux `fuse` package should be installed, on the MacOS `macfuse` can be used.
 The Unix users can use the following command for mounting the partition:
 
 ```sh
@@ -81,6 +82,23 @@ df -h mountpoint/ # will show information about free space
     umount mountpoint
 
 Note: for full access without root, use the argument `-o allow_other` when mounting.
+
+### pfsfuse-win32 ###
+
+Windows port uses [Dokan FUSE wrapper](https://github.com/dokan-dev/dokany) implementation as a base. Before using `pfsfuse` on Windows you should install Dokany. [Installation instructions](https://github.com/dokan-dev/dokany/wiki/Installation). After successful installation, you can use `pfsfuse` by pasting command in command line (CMD) or PowerShell with elevated privileges (run as administrator):
+```sh
+pfsfuse.exe --partition=+OPL \\.\PHYSICALDRIVE2 M -o volname=+OPL
+or
+pfsfuse.exe --partition=+OPL D:\ps2image.bin M -o volname=+OPL
+```
+
+Where `M` - is drive letter (please choose unused driver letter). `-o volname=+OPL` - will be volume name in File Explorer.
+For unmounting, please locate dokanctl.exe and launch the following command in the elevated command prompt:
+```sh
+dokanctl.exe /u M
+```
+Where `M` - is mounted point drive letter.
+
 ## NBD server support
 
 The latest Open PS2 Loader revisions have a built-in NBD server. `pfsshell/pfsfuse` have full support for an NBD block device, once an NBD server is mounted in the host filesystem.

--- a/dokany.sh
+++ b/dokany.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+rm -rf external/dokany/dokan_fuse/build
+mkdir external/dokany/dokan_fuse/build
+cmake -G 'MinGW Makefiles' -Sexternal/dokany/dokan_fuse -Bexternal/dokany/dokan_fuse/build -DCMAKE_SHARED_LINKER_FLAGS="-static -static-libgcc -static-libstdc++" -DCMAKE_INSTALL_PREFIX='./build'
+mingw32-make -C external/dokany/dokan_fuse/build
+cp -f external/dokany/dokan_fuse/build/libdokanfuse*.dll build/

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('pfsshell', 'c', default_options: ['optimization=0', 'debug=true', 'warning_level=1'], version: 'v1.1.1')
+project('pfsshell', 'c', default_options: ['optimization=0', 'debug=true', 'warning_level=0'], version: 'v1.1.1')
 
 add_global_arguments(['-Wno-unused-value', '-Wno-format', '-Wno-format-security', '-Wno-unused-function', '-Wno-unused-variable'], language : 'c')
 
@@ -51,7 +51,18 @@ pfsshell = executable('pfsshell', sources: pfsshell_src, c_args: pfsshell_cflags
 libps2hdd = shared_library('ps2hdd', sources: pfsshell_src, c_args: pfsshell_cflags, link_args: pfsshell_ldflags, dependencies: pfsshell_dependson, install: true)
 
 if get_option('enable_pfsfuse') == true
-libfuse_dep = dependency('fuse')
+
+if host_system == 'windows' and cc.get_id() != 'msvc' and cc.get_id() != 'clang-cl'
+	#Build libdokanfuse using CMake
+	run_command('./dokany.sh')
+	libfuse_include = include_directories(['external/dokany/dokan_fuse/include'])
+	libfuse_dep = cc.find_library('libdokanfuse2.dll',
+               dirs : [meson.current_source_dir() +'/external/dokany/dokan_fuse/build'])
+else
+	libfuse_include = ['']
+	libfuse_dep = dependency('fuse')
+endif
+
 pfsfuse_src = [
 	'iomanx_adapter.c',
 ]
@@ -74,7 +85,7 @@ pfsfuse_dependson = [
 	libiomanX_dep,
 	libfuse_dep,
 ]
-pfsfuse = executable('pfsfuse', sources: pfsfuse_src, c_args: pfsfuse_cflags, link_args: pfsfuse_ldflags, dependencies: pfsfuse_dependson, install: true)
+pfsfuse = executable('pfsfuse', sources: pfsfuse_src, include_directories : libfuse_include, c_args: pfsfuse_cflags, link_args: pfsfuse_ldflags, dependencies: pfsfuse_dependson, install: true)
 endif
 
 if host_system == 'windows' and cc.get_id() != 'msvc' and cc.get_id() != 'clang-cl'


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [ ] I checked to make sure my submission worked
- [ ] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description

Ported great @parrado work to be compatible with other platforms. Also updated code to be compatible with recently released Dokany v2. Currently, looks like most of the functions are working. Looks like `ftruncate/truncate` method isn't working. The truncate method allows to change the file size, if this method doesn't work, you cannot change filesize. That means you should avoid directly editing files on the mounted partition. You also will get an error, trying to overwrite the file, so be careful when copying files - you should remove them before copying. I am not quite sure why this happened, maybe I made some mistake during porting @parrado work.

@uyjulian I was not able to compile pfsfuse using cross-compilation on Ubuntu, so I made another GitHub action for compiling it natively in MSYS2 on windows.