### PR TITLE
added <fstype> argument to mkpart

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,8 +3,10 @@ Language:        Cpp
 AccessModifierOffset: -4
 AlignAfterOpenBracket: Align
 AlignConsecutiveAssignments: false
+AlignConsecutiveBitFields: AcrossEmptyLinesAndComments
 AlignConsecutiveDeclarations: false
-AlignEscapedNewlinesLeft: false
+AlignConsecutiveMacros: AcrossComments
+AlignEscapedNewlines: Left
 AlignOperands:   true
 AlignTrailingComments: true
 AllowAllParametersOfDeclarationOnNextLine: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,23 +106,6 @@ jobs:
           name: pfsshell-win32
           path: build/*.7z
 
-      - name: Build pfsfuse
-        continue-on-error: true
-        run: |
-          rm -rf build/
-          meson setup build/ -Denable_pfsfuse=true --cross-file ./external/meson_toolchains/mingw32_meson.ini
-          meson compile -C build
-          cp -f external/dokany/license.lgpl.txt build/
-
-      - uses: actions/upload-artifact@master
-        continue-on-error: true
-        with:
-          name: pfsfuse-win32
-          path: |
-            build/pfsfuse.exe
-            build/libdokanfuse*.dll
-            build/license.lgpl.txt
-
   build-pfsfuse-win32:
     runs-on: windows-latest
     defaults:

--- a/hl.c
+++ b/hl.c
@@ -175,6 +175,8 @@ int lspart(int lsmode)
 #endif
         int result;
         iox_dirent_t dirent;
+        if (lsmode == 1)
+            printf("Start (sector)  Code      Size         Timestamp  Name\n");
         while ((result = iomanx_dread(dh, &dirent)) && result != -1) {
 
             // Equal to, but avoids overflows of: size * 512 / 1024 / 1024;
@@ -201,8 +203,8 @@ int lspart(int lsmode)
                 printf("%s%s\n",
                        dirent.name, end_symbol);
             else if (lsmode == 1)
-                printf("0x%04x %7uMB  %s  %s%s\n",
-                       dirent.stat.mode, size, mod_time, dirent.name, end_symbol);
+                printf("%#8x        %04X %7uMB  %s  %s%s\n",
+                       dirent.stat.private_5, dirent.stat.mode, size, mod_time, dirent.name, end_symbol);
         }
 
         result = iomanx_close(dh);

--- a/hl.c
+++ b/hl.c
@@ -252,10 +252,10 @@ int ls(const char *mount_point, const char *path)
 
 
 /* create PFS onto an existing partition */
-int mkfs(const char *mount_point)
+int mkpfs(const char *mount_point)
 {
 #define PFS_ZONE_SIZE 8192
-#define PFS_FRAGMENT 0x00000000
+#define PFS_FRAGMENT  0x00000000
     int format_arg[] = {PFS_ZONE_SIZE, 0x2d66, PFS_FRAGMENT};
 
     char tmp[256];
@@ -266,8 +266,7 @@ int mkfs(const char *mount_point)
 }
 
 
-/* create partition and format it as PFS;
- * so far the only sizes supported are powers of 2 */
+/* create partition of any type and format it as PFS if type=0x0100 */
 int mkpart(const char *mount_point, long size_in_mb, int format)
 {
     char tmp[256];
@@ -280,7 +279,7 @@ int mkpart(const char *mount_point, long size_in_mb, int format)
         iomanx_close(result), result = 0;
 
         if (format)
-            result = mkfs(mount_point);
+            result = mkpfs(mount_point);
     }
     return (result);
 }
@@ -292,10 +291,10 @@ int initialize(void)
 {
     int result = iomanx_format("hdd0:", NULL, NULL, 0);
     if (result >= 0) {
-        result = mkfs("__net");
-        mkfs("__system");
-        mkfs("__sysconf");
-        mkfs("__common");
+        result = mkpfs("__net");
+        mkpfs("__system");
+        mkpfs("__sysconf");
+        mkpfs("__common");
     }
     return (result);
 }

--- a/hl.h
+++ b/hl.h
@@ -14,12 +14,12 @@ int ls(const char *mount_point, const char *path);
 int lspart(int lsmode);
 
 /* create PFS onto an existing partition */
-int mkfs(const char *mount_point);
+int mkpfs(const char *mount_point);
 
-/* create partition and (optionally) format it as PFS;
+/* create partition of any type and format it as PFS if type=0x0100;
  * so far the only sizes supported are powers of 2 */
 int mkpart(const char *mount_point, long size_in_mb, int format);
 
 /* initialize PS2 HDD with APA partitioning and create common partitions
- * (__mbr, __common, __net, etc.); common partitions are not PFS-formatted */
+ * (__mbr, __common, __net, etc.) */
 int initialize(void);

--- a/shell.c
+++ b/shell.c
@@ -206,10 +206,10 @@ static int do_initialize(context_t *ctx, int argc, char *argv[])
     } else {
         int result = iomanx_format("hdd0:", NULL, NULL, 0);
         if (result >= 0) {
-            result = mkfs("__net");
-            mkfs("__system");
-            mkfs("__sysconf");
-            mkfs("__common");
+            result = mkpfs("__net");
+            mkpfs("__system");
+            mkpfs("__sysconf");
+            mkpfs("__common");
         }
         if (result < 0)
             fprintf(stderr, "(!) format: %s.\n", strerror(-result));
@@ -218,7 +218,7 @@ static int do_initialize(context_t *ctx, int argc, char *argv[])
 }
 
 /*
-static int do_mkfs(context_t *ctx, int argc, char *argv[])
+static int do_mkpfs(context_t *ctx, int argc, char *argv[])
 {
 #define PFS_ZONE_SIZE 8192
 #define PFS_FRAGMENT 0x00000000
@@ -234,6 +234,8 @@ static int do_mkfs(context_t *ctx, int argc, char *argv[])
     return (result);
 }
 */
+
+/* PFS, CFS, HDL, REISER, EXT2, EXT2SWAP, MBR */
 
 static int do_mkpart(context_t *ctx, int arg, char *argv[])
 {
@@ -260,10 +262,20 @@ static int do_mkpart(context_t *ctx, int arg, char *argv[])
         16384,
         32768};
 
+    static char *fsType[7] = {
+        "MBR",
+        "EXT2SWAP",
+        "EXT2",
+        "REISER",
+        "PFS",
+        "CFS",
+        "HDL"};
+
     unsigned int size_in_mb = 0;
 
     char tmp[128];
     char openString[32 + 5];
+    char part_type[9];
     int i = 9;
     int result = -1;
     int partfd = 0;
@@ -271,7 +283,6 @@ static int do_mkpart(context_t *ctx, int arg, char *argv[])
     sprintf(openString, "hdd0:%s", argv[1]);
     openString[32 + 5 - 1] = '\0';
     partfd = iomanx_open(openString, IOMANX_O_RDONLY);
-    printf("iomanx_open %d\n", partfd);
     if (partfd != -2) // partition already exists+
     {
         iomanx_close(partfd);
@@ -286,14 +297,25 @@ static int do_mkpart(context_t *ctx, int arg, char *argv[])
         argv[2][strlen(argv[2]) - 1] = '\0';
         size_in_mb = strtoul(argv[2], NULL, 10) * 1024;
     } else {
-        fprintf(stderr, "%s: invalid partition size.\n", argv[2]);
+        fprintf(stderr, "%s: Partition size should end with literal M or G.\n", argv[2]);
         return (-1);
+    }
+    for (size_t j = 0; j < 8; j++) {
+        if (j == 7) {
+            fprintf(stderr, "%s: wrong fs type. Acceptable fs types: {PFS, CFS, HDL, REISER, EXT2, EXT2SWAP, MBR}.\n", argv[3]);
+            return (-1);
+        } else if (strcmp(argv[3], fsType[j]) == 0) {
+            sprintf(part_type, "%s", fsType[j]);
+            part_type[strlen(fsType[j])] = '\0';
+            break;
+        }
     }
 
     while (result < 0 && i > 0) { // create main partition
         i--;
         if (sizesMB[i] <= size_in_mb) {
-            sprintf(tmp, "hdd0:%s,,,%s,PFS", argv[1], sizesString[i]);
+            sprintf(tmp, "hdd0:%s,,,%s,%s", argv[1], sizesString[i], part_type);
+
             partfd = iomanx_open(tmp, IOMANX_O_RDWR | IOMANX_O_CREAT);
             if (partfd >= 0) {
                 printf("Main partition of %s created.\n", sizesString[i]);
@@ -324,7 +346,8 @@ static int do_mkpart(context_t *ctx, int arg, char *argv[])
     if (result >= 0) {
         (void)iomanx_close(partfd), result = 0;
         if (result >= 0)
-            result = mkfs(argv[1]);
+            if (strncmp(part_type, "PFS", 3) == 0)
+                result = mkpfs(argv[1]);
     }
 
     if (result < 0)
@@ -581,8 +604,10 @@ static int do_help(context_t *ctx, int argc, char *argv[])
         "lcd [path] - print/change the local working directory\n"
         "device <device> - use this PS2 HDD;\n"
         "initialize - blank and create APA/PFS on a new PS2 HDD (destructive);\n"
-        "mkpart <part_name> <size> - create a new PFS formatted partition;\n"
+        "mkpart <part_name> <size> <fstype> - create a new PFS formatted partition;\n"
         "\tSize must end with M or G literal (like 384M or 3G);\n"
+        "\tAcceptable fs types: {PFS, CFS, HDL, REISER, EXT2, EXT2SWAP, MBR};\n"
+        "\tOnly fs type PFS will format partition, other partitions should be formatted by another utilities;\n"
         "mount <part_name> - mount a partition;\n"
         "umount - un-mount a partition;\n"
         "ls [-l] - no mount: list partitions; mount: list files/dirs;\n"
@@ -619,8 +644,8 @@ static int exec(void *data, int argc, char *argv[])
         {"device", 1, need_no_device, &do_device},
         {"initialize", 0, need_device + need_no_mount, &do_initialize},
         {"initialize", 1, need_device + need_no_mount, &do_initialize},
-        {"mkpart", 2, need_device, &do_mkpart},
-        /* {"mkfs", 1, need_device, &do_mkfs}, */
+        {"mkpart", 3, need_device, &do_mkpart},
+        /* {"mkpfs", 1, need_device, &do_mkpfs}, */
         {"mount", 1, need_device + need_no_mount, &do_mount},
         {"umount", 0, need_device + need_mount, &do_umount},
         {"ls", 0, need_device, &do_ls},

--- a/shell.c
+++ b/shell.c
@@ -306,7 +306,6 @@ static int do_mkpart(context_t *ctx, int arg, char *argv[])
             return (-1);
         } else if (strcmp(argv[3], fsType[j]) == 0) {
             sprintf(part_type, "%s", fsType[j]);
-            part_type[strlen(fsType[j])] = '\0';
             break;
         }
     }

--- a/subprojects/apa/irx/apa-opt.h
+++ b/subprojects/apa/irx/apa-opt.h
@@ -2,12 +2,12 @@
 #define _APA_OPT_H
 
 #define APA_PRINTF(format, ...) printf(format, ##__VA_ARGS__)
-#define APA_DRV_NAME "hdd"
+#define APA_DRV_NAME            "hdd"
 
 #if 1
-#define APA_STAT_RETURN_PART_LBA 1
+#define APA_STAT_RETURN_PART_LBA   1
 #define APA_FORMAT_MAKE_PARTITIONS 1
-#define APA_FORMAT_LOCK_MBR 1
+#define APA_FORMAT_LOCK_MBR        1
 #else
 /*	Define APA_OSD_VER in your Makefile to build an OSD version, which will:
         1. (currently disabled) When formatting, do not create any partitions
@@ -20,12 +20,12 @@
 
 #ifdef APA_OSD_VER
 #define APA_STAT_RETURN_PART_LBA 1
-#define APA_FORMAT_LOCK_MBR 1
+#define APA_FORMAT_LOCK_MBR      1
 #define APA_FORMAT_MAKE_PARTITIONS \
     1 // For now, define this because I don't think we're ready (and want to) deal \
         // with the official passwords.
 #else
-#define APA_ENABLE_PASSWORDS 1
+#define APA_ENABLE_PASSWORDS       1
 #define APA_FORMAT_MAKE_PARTITIONS 1
 #endif
 #endif

--- a/subprojects/apa/irx/hdd.c
+++ b/subprojects/apa/irx/hdd.c
@@ -112,7 +112,7 @@ apa_cache_t *hddAddPartitionHere(s32 device, const apa_params_t *params, u32 *em
     tmp = some_size ? params->size - some_size : 0;
 
     if (hddDevices[device].totalLBA < (part_end + params->size + tmp)
-        //Non-SONY: when dealing with large disks, this check may overflow (therefore, check for overflows!).
+        // Non-SONY: when dealing with large disks, this check may overflow (therefore, check for overflows!).
         || (part_end < sector)) {
         *err = -ENOSPC;
         apaCacheFree(clink_this);

--- a/subprojects/apa/irx/hdd_fio.c
+++ b/subprojects/apa/irx/hdd_fio.c
@@ -102,10 +102,12 @@ static int fioGetInput(const char *arg, apa_params_t *params)
     char argBuf[32];
     int rv = 0, i;
     static const struct apaFsType fsTypes[] = {
+        {"MBR", APA_TYPE_MBR},
+        {"EXT2SWAP", APA_TYPE_EXT2SWAP},
+        {"EXT2", APA_TYPE_EXT2},
+        {"REISER", APA_TYPE_REISER},
         {"PFS", APA_TYPE_PFS},
         {"CFS", APA_TYPE_CFS},
-        {"EXT2", APA_TYPE_EXT2},
-        {"EXT2SWAP", APA_TYPE_EXT2SWAP},
         {"HDL", APA_TYPE_HDL}};
 
     if (params == NULL)
@@ -152,14 +154,14 @@ static int fioGetInput(const char *arg, apa_params_t *params)
     if ((rv = fioInputBreaker(&arg, argBuf, sizeof(argBuf))) != 0)
         return rv;
 
-    for (i = 0; i < 5; i++) {
+    for (i = 0; i < 7; i++) {
         if (!strcmp(argBuf, fsTypes[i].desc)) {
             params->type = fsTypes[i].type;
             break;
         }
     }
 
-    if (i == 5) {
+    if (i == 7) {
         printf("hdd: error: Invalid fstype, %s.\n", argBuf);
         return -EINVAL;
     }
@@ -653,8 +655,8 @@ int hddDread(iop_file_t *f, iox_dirent_t *dirent)
             apa_cache_t *cmain = apaCacheGetHeader(f->unit, clink->header->main, APA_IO_MODE_READ, &rv);
             if (cmain != NULL) {
                 /*	This was the SONY original, which didn't do bounds-checking:
-				rv=strlen(cmain->header->id);
-				strcpy(dirent->name, cmain->header->id); */
+                rv=strlen(cmain->header->id);
+                strcpy(dirent->name, cmain->header->id); */
                 strncpy(dirent->name, cmain->header->id, APA_IDMAX);
                 dirent->name[APA_IDMAX] = '\0';
                 rv = strlen(dirent->name);
@@ -663,8 +665,8 @@ int hddDread(iop_file_t *f, iox_dirent_t *dirent)
             }
         } else {
             /*	This was the SONY original, which didn't do bounds-checking:
-			rv=strlen(clink->header->id);
-			strcpy(dirent->name, clink->header->id); */
+            rv=strlen(clink->header->id);
+            strcpy(dirent->name, clink->header->id); */
             strncpy(dirent->name, clink->header->id, APA_IDMAX);
             dirent->name[APA_IDMAX] = '\0';
             rv = strlen(dirent->name);
@@ -681,10 +683,10 @@ int hddDread(iop_file_t *f, iox_dirent_t *dirent)
 }
 
 /*	Originally, SONY provided no function for renaming partitions.
-	Syntax:	rename <Old ID>,<fpwd> <New ID>,<fpwd>
+    Syntax:	rename <Old ID>,<fpwd> <New ID>,<fpwd>
 
-	The full-access password (fpwd) is required.
-	System partitions (__*) cannot be renamed.	*/
+    The full-access password (fpwd) is required.
+    System partitions (__*) cannot be renamed.	*/
 int hddReName(iop_file_t *f, const char *oldname, const char *newname)
 {
     apa_params_t oldParams;
@@ -878,7 +880,7 @@ static int devctlSwapTemp(s32 device, char *argp)
             memcpy(partTemp->header->id, partNew->header->id, APA_IDMAX);
             memcpy(partTemp->header->rpwd, partNew->header->rpwd, APA_PASSMAX);
             memcpy(partTemp->header->fpwd, partNew->header->fpwd, APA_PASSMAX);
-            //memset(partNew->header->id, 0, 8);// BUG! can make it so can not open!!
+            // memset(partNew->header->id, 0, 8);// BUG! can make it so can not open!!
             memset(partNew->header->id, 0, APA_IDMAX);
             strcpy(partNew->header->id, "_tmp");
             memset(partNew->header->rpwd, 0, APA_PASSMAX);

--- a/subprojects/fakeps2sdk/include/atad.h
+++ b/subprojects/fakeps2sdk/include/atad.h
@@ -3,7 +3,7 @@
 #include <sysclib.h>
 
 /* These are used with the dir parameter of ata_device_sector_io().  */
-#define ATA_DIR_READ 0
+#define ATA_DIR_READ  0
 #define ATA_DIR_WRITE 1
 
 typedef struct _ata_devinfo
@@ -17,10 +17,10 @@ typedef struct _ata_devinfo
 ata_devinfo_t *ata_get_devinfo(int device);
 int ata_device_sector_io(int device, void *buf, u32 lba, u32 nsectors, int dir);
 
-#define ata_device_sce_sec_unlock(x, y) 0
-#define ata_device_idle(x, y) 0
-#define ata_device_idle_immediate(x) 0
+#define ata_device_sce_sec_unlock(x, y)     0
+#define ata_device_idle(x, y)               0
+#define ata_device_idle_immediate(x)        0
 #define ata_device_sce_identify_drive(x, y) -1
-#define ata_device_smart_get_status(x) 0
-#define ata_device_smart_save_attr(x) 0
-#define ata_device_flush_cache(x) 0
+#define ata_device_smart_get_status(x)      0
+#define ata_device_smart_save_attr(x)       0
+#define ata_device_flush_cache(x)           0

--- a/subprojects/fakeps2sdk/include/hdd-ioctl.h
+++ b/subprojects/fakeps2sdk/include/hdd-ioctl.h
@@ -1,19 +1,20 @@
 #pragma once
 
-//apa
+// apa
 
 // Partition format/types (as returned via the mode field for getstat/dread)
-#define APA_TYPE_FREE 0x0000
-#define APA_TYPE_MBR 0x0001 // Master Boot Record
+#define APA_TYPE_FREE     0x0000
+#define APA_TYPE_MBR      0x0001 // Master Boot Record
 #define APA_TYPE_EXT2SWAP 0x0082
-#define APA_TYPE_EXT2 0x0083
-#define APA_TYPE_PFS 0x0100
-#define APA_TYPE_CFS 0x0101
-#define APA_TYPE_HDL 0x1337
+#define APA_TYPE_EXT2     0x0083
+#define APA_TYPE_REISER   0x0088
+#define APA_TYPE_PFS      0x0100
+#define APA_TYPE_CFS      0x0101
+#define APA_TYPE_HDL      0x1337
 
-#define APA_IDMAX 32
-#define APA_MAXSUB 64 // Maximum # of sub-partitions
-#define APA_PASSMAX 8
+#define APA_IDMAX    32
+#define APA_MAXSUB   64 // Maximum # of sub-partitions
+#define APA_PASSMAX  8
 #define APA_FLAG_SUB 0x0001 // Sub-partition status for partitions (attr field)
 
 //
@@ -21,20 +22,20 @@
 //
 #define HIOCADDSUB 0x6801
 #define HIOCDELSUB 0x6802
-#define HIOCNSUB 0x6803
-#define HIOCFLUSH 0x6804
+#define HIOCNSUB   0x6803
+#define HIOCFLUSH  0x6804
 
 // Arbitrarily-named commands
-#define HIOCTRANSFER 0x6832     // Used by PFS.IRX to read/write data
-#define HIOCGETSIZE 0x6833      // For main(0)/subs(1+)
+#define HIOCTRANSFER     0x6832 // Used by PFS.IRX to read/write data
+#define HIOCGETSIZE      0x6833 // For main(0)/subs(1+)
 #define HIOCSETPARTERROR 0x6834 // Set (sector of a partition) that has an error
 #define HIOCGETPARTERROR 0x6835 // Get (sector of a partition) that has an error
 
-//HDLFS addition
+// HDLFS addition
 #define HIOCGETPARTSTART 0x6836 // Get the sector number of the first sector of the partition.
 
 // I/O direction
-#define APA_IO_MODE_READ 0x00
+#define APA_IO_MODE_READ  0x00
 #define APA_IO_MODE_WRITE 0x01
 
 // structs for IOCTL2 commands
@@ -51,27 +52,27 @@ typedef struct
 // DEVCTL commands
 //
 // 'H' set
-#define HDIOC_MAXSECTOR 0x4801   // Maximum partition size (in sectors)
+#define HDIOC_MAXSECTOR   0x4801 // Maximum partition size (in sectors)
 #define HDIOC_TOTALSECTOR 0x4802 // Capacity of the disk (in sectors)
-#define HDIOC_IDLE 0x4803
-#define HDIOC_FLUSH 0x4804
-#define HDIOC_SWAPTMP 0x4805
-#define HDIOC_DEV9OFF 0x4806
-#define HDIOC_STATUS 0x4807
-#define HDIOC_FORMATVER 0x4808
-#define HDIOC_SMARTSTAT 0x4809
-#define HDIOC_FREESECTOR 0x480A // Returns the approximate amount of free space
-#define HDIOC_IDLEIMM 0x480B
+#define HDIOC_IDLE        0x4803
+#define HDIOC_FLUSH       0x4804
+#define HDIOC_SWAPTMP     0x4805
+#define HDIOC_DEV9OFF     0x4806
+#define HDIOC_STATUS      0x4807
+#define HDIOC_FORMATVER   0x4808
+#define HDIOC_SMARTSTAT   0x4809
+#define HDIOC_FREESECTOR  0x480A // Returns the approximate amount of free space
+#define HDIOC_IDLEIMM     0x480B
 
 // 'h' command set
 // Arbitrarily-named commands
-#define HDIOC_GETTIME 0x6832
-#define HDIOC_SETOSDMBR 0x6833 // arg = hddSetOsdMBR_t
-#define HDIOC_GETSECTORERROR 0x6834
+#define HDIOC_GETTIME          0x6832
+#define HDIOC_SETOSDMBR        0x6833 // arg = hddSetOsdMBR_t
+#define HDIOC_GETSECTORERROR   0x6834
 #define HDIOC_GETERRORPARTNAME 0x6835 // bufp = namebuffer[0x20]
-#define HDIOC_READSECTOR 0x6836       // arg  = hddAtaTransfer_t
-#define HDIOC_WRITESECTOR 0x6837      // arg  = hddAtaTransfer_t
-#define HDIOC_SCEIDENTIFY 0x6838      // bufp = buffer for atadSceIdentifyDrive
+#define HDIOC_READSECTOR       0x6836 // arg  = hddAtaTransfer_t
+#define HDIOC_WRITESECTOR      0x6837 // arg  = hddAtaTransfer_t
+#define HDIOC_SCEIDENTIFY      0x6838 // bufp = buffer for atadSceIdentifyDrive
 
 // structs for DEVCTL commands
 
@@ -88,31 +89,31 @@ typedef struct
     u32 size;
 } hddSetOsdMBR_t;
 
-//pfs
+// pfs
 
 // IOCTL2 commands
 // Command set 'p'
-#define PIOCALLOC 0x7001
-#define PIOCFREE 0x7002
-#define PIOCATTRADD 0x7003
-#define PIOCATTRDEL 0x7004
+#define PIOCALLOC      0x7001
+#define PIOCFREE       0x7002
+#define PIOCATTRADD    0x7003
+#define PIOCATTRDEL    0x7004
 #define PIOCATTRLOOKUP 0x7005
-#define PIOCATTRREAD 0x7006
-#define PIOCINVINODE 0x7032 //Only available in OSD version. Arbitrarily named.
+#define PIOCATTRREAD   0x7006
+#define PIOCINVINODE   0x7032 // Only available in OSD version. Arbitrarily named.
 
 // DEVCTL commands
 // Command set 'P'
-#define PDIOC_ZONESZ 0x5001
-#define PDIOC_ZONEFREE 0x5002
-#define PDIOC_CLOSEALL 0x5003
+#define PDIOC_ZONESZ      0x5001
+#define PDIOC_ZONEFREE    0x5002
+#define PDIOC_CLOSEALL    0x5003
 #define PDIOC_GETFSCKSTAT 0x5004
 #define PDIOC_CLRFSCKSTAT 0x5005
 
 // Arbitrarily-named commands
-#define PDIOC_SETUID 0x5032
-#define PDIOC_SETGID 0x5033
+#define PDIOC_SETUID     0x5032
+#define PDIOC_SETGID     0x5033
 #define PDIOC_SHOWBITMAP 0xFF
 
 // I/O direction
-#define PFS_IO_MODE_READ 0x00
+#define PFS_IO_MODE_READ  0x00
 #define PFS_IO_MODE_WRITE 0x01

--- a/subprojects/fakeps2sdk/include/intrman.h
+++ b/subprojects/fakeps2sdk/include/intrman.h
@@ -1,4 +1,4 @@
 #pragma once
 
 #define CpuSuspendIntr(x) 0
-#define CpuResumeIntr(x) 0
+#define CpuResumeIntr(x)  0

--- a/subprojects/fakeps2sdk/include/iomanX.h
+++ b/subprojects/fakeps2sdk/include/iomanX.h
@@ -2,16 +2,16 @@
 
 #include "irx.h"
 
-#define O_RDONLY 0x0001
-#define O_WRONLY 0x0002
-#define O_RDWR 0x0003
+#define O_RDONLY  0x0001
+#define O_WRONLY  0x0002
+#define O_RDWR    0x0003
 #define O_DIROPEN 0x0008 // Internal use for dopen
-#define O_NBLOCK 0x0010
-#define O_APPEND 0x0100
-#define O_CREAT 0x0200
-#define O_TRUNC 0x0400
-#define O_EXCL 0x0800
-#define O_NOWAIT 0x8000
+#define O_NBLOCK  0x0010
+#define O_APPEND  0x0100
+#define O_CREAT   0x0200
+#define O_TRUNC   0x0400
+#define O_EXCL    0x0800
+#define O_NOWAIT  0x8000
 
 #define SEEK_SET 0
 #define SEEK_CUR 1
@@ -20,11 +20,11 @@
 /* Device drivers.  */
 
 /* Device types.  */
-#define IOP_DT_CHAR 0x01
-#define IOP_DT_CONS 0x02
+#define IOP_DT_CHAR  0x01
+#define IOP_DT_CONS  0x02
 #define IOP_DT_BLOCK 0x04
-#define IOP_DT_RAW 0x08
-#define IOP_DT_FS 0x10
+#define IOP_DT_RAW   0x08
+#define IOP_DT_FS    0x10
 #ifndef IOMAN_NO_EXTENDED
 #define IOP_DT_FSEXT 0x10000000 /* Supports calls after chstat().  */
 #endif
@@ -33,13 +33,13 @@
 #define FIO_CST_MODE 0x0001
 #define FIO_CST_ATTR 0x0002
 #define FIO_CST_SIZE 0x0004
-#define FIO_CST_CT 0x0008
-#define FIO_CST_AT 0x0010
-#define FIO_CST_MT 0x0020
+#define FIO_CST_CT   0x0008
+#define FIO_CST_AT   0x0010
+#define FIO_CST_MT   0x0020
 #define FIO_CST_PRVT 0x0040
 
 // File mode flags
-#define FIO_S_IFMT 0xF000  // Format mask
+#define FIO_S_IFMT  0xF000 // Format mask
 #define FIO_S_IFLNK 0x4000 // Symbolic link
 #define FIO_S_IFREG 0x2000 // Regular file
 #define FIO_S_IFDIR 0x1000 // Directory
@@ -76,7 +76,7 @@ typedef struct _iop_file
     s32 unit;                   /* HW device unit number.  */
     struct _iop_device *device; /* Device driver.  */
     void *privdata;             /* The device driver can use this however it
-				   wants.  */
+                   wants.  */
 } iop_file_t;
 
 typedef struct _iop_device
@@ -89,32 +89,32 @@ typedef struct _iop_device
 } iop_device_t;
 
 
-#define open iomanx_open
-#define close iomanx_close
-#define read iomanx_read
-#define write iomanx_write
-#define lseek iomanx_lseek
-#define ioctl iomanx_ioctl
-#define remove iomanx_remove
-#define mkdir iomanx_mkdir
-#define rmdir iomanx_rmdir
-#define dopen iomanx_dopen
-#define dclose iomanx_dclose
-#define dread iomanx_dread
+#define open    iomanx_open
+#define close   iomanx_close
+#define read    iomanx_read
+#define write   iomanx_write
+#define lseek   iomanx_lseek
+#define ioctl   iomanx_ioctl
+#define remove  iomanx_remove
+#define mkdir   iomanx_mkdir
+#define rmdir   iomanx_rmdir
+#define dopen   iomanx_dopen
+#define dclose  iomanx_dclose
+#define dread   iomanx_dread
 #define getstat iomanx_getstat
-#define chstat iomanx_chstat
+#define chstat  iomanx_chstat
 
-#define format iomanx_format
-#define rename iomanx_rename
-#define chdir iomanx_chdir
-#define sync iomanx_sync
-#define mount iomanx_mount
-#define umount iomanx_umount
-#define lseek64 iomanx_lseek64
-#define devctl iomanx_devctl
-#define symlink iomanx_symlink
+#define format   iomanx_format
+#define rename   iomanx_rename
+#define chdir    iomanx_chdir
+#define sync     iomanx_sync
+#define mount    iomanx_mount
+#define umount   iomanx_umount
+#define lseek64  iomanx_lseek64
+#define devctl   iomanx_devctl
+#define symlink  iomanx_symlink
 #define readlink iomanx_readlink
-#define ioctl2 iomanx_ioctl2
+#define ioctl2   iomanx_ioctl2
 
 
 typedef struct _iop_device_ops
@@ -194,7 +194,7 @@ void StdioInit(int mode);
 
 
 // Access flags for filesystem mount
-#define FIO_MT_RDWR 0x00
+#define FIO_MT_RDWR   0x00
 #define FIO_MT_RDONLY 0x01
 
 #define IOMANX_SEEK_SET 0
@@ -202,7 +202,7 @@ void StdioInit(int mode);
 #define IOMANX_SEEK_END 2
 
 // File mode flags (for mode in io_stat_t)
-#define FIO_SO_IFMT 0x0038  // Format mask
+#define FIO_SO_IFMT  0x0038 // Format mask
 #define FIO_SO_IFLNK 0x0008 // Symbolic link
 #define FIO_SO_IFREG 0x0010 // Regular file
 #define FIO_SO_IFDIR 0x0020 // Directory

--- a/subprojects/fakeps2sdk/include/loadcore.h
+++ b/subprojects/fakeps2sdk/include/loadcore.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#define MODULE_RESIDENT_END 0
+#define MODULE_RESIDENT_END    0
 #define MODULE_NO_RESIDENT_END 1
 
-#define FlushIcache() 0
+#define FlushIcache()             0
 #define RegisterLibraryEntries(x) 0

--- a/subprojects/fakeps2sdk/include/types.h
+++ b/subprojects/fakeps2sdk/include/types.h
@@ -14,7 +14,7 @@ typedef struct
     /*14*/ unsigned char atime[8];
     /*1c*/ unsigned char mtime[8];
     /*24*/ unsigned int hisize;
-    /*28*/ unsigned int private_0; //Number of subs (main) / subpart number (sub)
+    /*28*/ unsigned int private_0; // Number of subs (main) / subpart number (sub)
     /*2c*/ unsigned int private_1;
     /*30*/ unsigned int private_2;
     /*34*/ unsigned int private_3;

--- a/test/pfsshell_test.tcl
+++ b/test/pfsshell_test.tcl
@@ -81,7 +81,7 @@ __sysconf/\r
 __common/\r
 # "
 
-run_cmd "mkpart" "mkpart PP.TEST 128M" "-exact" "# "
+run_cmd "mkpart" "mkpart PP.TEST 128M PFS" "-exact" "# "
 run_cmd "mkpart" "ls" "-exact" "
 __mbr\r
 __net/\r


### PR DESCRIPTION
mkpart errors now are more informative #31
clang-format a bit adjusted

## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [ ] I checked to make sure my submission worked
- [ ] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description

Now it will be possible to create other than PFS partitions. Only PFS partitions will be formatted on creation, other partitions should be formatted manually. Also #31 issue taken into account and now pfsshell will print proper error message.
mkpart now will have such a syntax:
```
mkpart __linux.1 1G EXT2
mkpart PP.TEST 128M PFS
```
Supported <fstype> list: {PFS, CFS, HDL, REISER, EXT2, EXT2SWAP, MBR}

As always, `help` command will print all details about all commands.