### PR TITLE
Fix named semaphore init value.

### DIFF
--- a/subprojects/fakeps2sdk/thsemap.c
+++ b/subprojects/fakeps2sdk/thsemap.c
@@ -27,7 +27,7 @@ int CreateSema(iop_sema_t *sema)
 #ifdef USE_NAMED_SEMAPHORES
         char sema_name_buf[NAME_MAX - 4];
         snprintf(sema_name_buf, sizeof(sema_name_buf), "fakeps2sdk%x_%i", getpid(), i);
-        sem[i] = sem_open((const char *)sema_name_buf, O_CREAT);
+        sem[i] = sem_open((const char *)sema_name_buf, O_CREAT, O_RDWR, 1);
 #else
         sem[i] = (sem_t *)malloc(sizeof(sem_t));
 #endif


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [x] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [n/a] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description
Fixes initial value of semaphore when using named semaphores. pfsshell was deadlocking when running on macOS otherwise.