### PR TITLE
Fix infinite prompt loop on stdin EOF

### DIFF
--- a/shell.c
+++ b/shell.c
@@ -111,13 +111,13 @@ static int shell_loop(FILE *in, FILE *out, FILE *err,
 
     while (true) {
         fputs(prompt, err);
-        getline(&line, &len, stdin);
-        if (!strncmp(line, "exit", 4) || !strncmp(line, "quit", 4) || !strncmp(line, "bye", 3)) {
+        int result = getline(&line, &len, stdin);
+        if (result < 0 || !strncmp(line, "exit", 4) || !strncmp(line, "quit", 4) || !strncmp(line, "bye", 3)) {
             break;
         }
         char *tokens[256];
         size_t count;
-        int result = parse_line(line, &tokens, &count);
+        result = parse_line(line, &tokens, &count);
         if (result >= 0) {
             errno = 0; /* reset */
             result = (*process)(data, count, tokens);


### PR DESCRIPTION
`^D` now exits the shell as it should.

## Pull Request checklist

Note: these are not necessarily requirements

- [x] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description

Fixes the following issue:

```bash
pfsshell < /dev/null
> > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >
```

Which also occurs if one uses ctrl+d in the prompt in an attempt to exit the shell.